### PR TITLE
Mandelbrot demo by Eemeli: Add Makefile for linux

### DIFF
--- a/Mandelbrot/Makefile
+++ b/Mandelbrot/Makefile
@@ -1,0 +1,9 @@
+OBJS = Mandelbrot.cpp shader.cpp gameloop.cpp
+CC = g++ -std=c++11
+COMPILER_FLAGS = -Wall
+LINKER_FLAGS = -lGL -lGLU -lglut -lGLEW -lglfw -lX11 -lXxf86vm -lXrandr -lpthread -lXi -ldl -lXinerama -lXcursor
+OBJ_NAME = main
+INC_DIRS = -I../Libraries -I../Libraries/glm
+
+all: $(OBJS)
+	$(CC) $(OBJS) $(COMPILER_FLAGS) $(LINKER_FLAGS) $(INC_DIRS) -o $(OBJ_NAME)


### PR DESCRIPTION
compiles on ubuntu 18.04 with following dependencies:
cmake libx11-dev xorg-dev libglu1-mesa-dev freeglut3-dev
libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev
libgl1-mesa-glx libgl1-mesa-dev libglfw3-dev

Not sure if all above are needed though.

executable tested to be functional

Signed-off-by: Antti Laakso <antti.h.laakso@gmail.com>